### PR TITLE
Update MESASDK and MESA SOURCE links.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
-FROM ghcr.io/hombit/mesa-src:12778-python3.7-stretch
+# FROM mesa_source
+FROM ghcr.io/hombit/mesa-src:12778-python3.10-bookworm
 
 RUN apt-get update &&\
-    apt-get install -y python3-pip python3-setuptools &&\
     apt-get clean -y &&\
     rm -rf /var/lib/apt/lists/* &&\
     truncate -s 0 /var/log/*log
@@ -16,6 +16,7 @@ env MESA_DIR=/mesa
 
 COPY call_mesa_script.sh setup.py /mesa2py/
 WORKDIR /mesa2py
+RUN source $MESASDK_ROOT/bin/mesasdk_init.sh
 RUN python3 setup.py buildmesa
 
 RUN pip3 install pytest pytest-subtests parameterized

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # FROM mesa_source
-FROM ghcr.io/hombit/mesa-src:12778-python3.10-bookworm
+FROM ghcr.io/hombit/mesa-src:12778-python3.11-bookworm
 
 RUN apt-get update &&\
     apt-get clean -y &&\

--- a/docker-mesa-src/Dockerfile
+++ b/docker-mesa-src/Dockerfile
@@ -5,17 +5,18 @@ ARG MESAVERSION=12778
 
 RUN ln -sfv /bin/bash /bin/sh
 
-RUN apt-get update &&\
-    apt-get install -y binutils bzip2 libc-dev libx11-dev libz-dev make subversion wget &&\
+# RUN apt-get update &&\
+RUN apt-get install -y binutils bzip2 libc-dev libx11-dev libz-dev make wget &&\
     apt-get clean -y &&\
     rm -rf /var/lib/apt/lists/* &&\
     truncate -s 0 /var/log/*log
 
-RUN wget --no-verbose -U "" -O /mesasdk.tar.gz http://www.astro.wisc.edu/~townsend/resource/download/mesasdk/mesasdk-x86_64-linux-${MESASDKVERSION}.tar.gz &&\
+RUN wget --no-verbose -U "" -O /mesasdk.tar.gz http://user.astro.wisc.edu/~townsend/resource/download/mesasdk/mesasdk-x86_64-linux-${MESASDKVERSION}.tar.gz &&\
     tar -xvf /mesasdk.tar.gz
 #     rm /mesasdk.tar.gz
 
-RUN svn co -r ${MESAVERSION} https://subversion.assembla.com/svn/mesa^mesa/trunk /mesa
+RUN wget --no-verbose -U "" -O /mesa.zip https://zenodo.org/records/3698354/files/mesa-r12778.zip?download=1
+RUN unzip /mesa.zip
 
 COPY etc_ld.so.conf.d_mesasdk.conf /etc/ld.so.conf.d/mesasdk.conf
 RUN ldconfig

--- a/docker-mesa-src/Dockerfile
+++ b/docker-mesa-src/Dockerfile
@@ -14,9 +14,10 @@ RUN apt-get update &&\
 RUN wget --no-verbose -U "" -O /mesasdk.tar.gz http://user.astro.wisc.edu/~townsend/resource/download/mesasdk/mesasdk-x86_64-linux-${MESASDKVERSION}.tar.gz &&\
     tar -xvf /mesasdk.tar.gz
 
-RUN wget --no-verbose -U "" -O /mesa.zip https://zenodo.org/records/3698354/files/mesa-r${MESASDKVERSION}.zip?download=1
+# BE CAREFUL, this is not a univeral link !!!
+RUN wget --no-verbose -U "" -O /mesa.zip https://zenodo.org/records/3698354/files/mesa-r${MESAVERSION}.zip?download=1
 RUN unzip /mesa.zip && rm mesa.zip
-RUN mv mesa-r${MESASDKVERSION} mesa
+RUN mv mesa-r${MESAVERSION} mesa
 
 COPY etc_ld.so.conf.d_mesasdk.conf /etc/ld.so.conf.d/mesasdk.conf
 RUN ldconfig

--- a/docker-mesa-src/Dockerfile
+++ b/docker-mesa-src/Dockerfile
@@ -13,11 +13,10 @@ RUN apt-get update &&\
 
 RUN wget --no-verbose -U "" -O /mesasdk.tar.gz http://user.astro.wisc.edu/~townsend/resource/download/mesasdk/mesasdk-x86_64-linux-${MESASDKVERSION}.tar.gz &&\
     tar -xvf /mesasdk.tar.gz
-RUN rm /mesasdk.tar.gz
 
-RUN wget --no-verbose -U "" -O /mesa.zip https://zenodo.org/records/3698354/files/mesa-r12778.zip?download=1
+RUN wget --no-verbose -U "" -O /mesa.zip https://zenodo.org/records/3698354/files/mesa-r${MESASDKVERSION}.zip?download=1
 RUN unzip /mesa.zip && rm mesa.zip
-RUN mv mesa-r12778 mesa
+RUN mv mesa-r${MESASDKVERSION} mesa
 
 COPY etc_ld.so.conf.d_mesasdk.conf /etc/ld.so.conf.d/mesasdk.conf
 RUN ldconfig

--- a/docker-mesa-src/Dockerfile
+++ b/docker-mesa-src/Dockerfile
@@ -15,9 +15,10 @@ RUN wget --no-verbose -U "" -O /mesasdk.tar.gz http://user.astro.wisc.edu/~towns
     tar -xvf /mesasdk.tar.gz
 
 # BE CAREFUL, this is not a univeral link !!!
-RUN wget --no-verbose -U "" -O /mesa.zip https://zenodo.org/records/3698354/files/mesa-r${MESAVERSION}.zip?download=1
-RUN unzip /mesa.zip && rm mesa.zip
-RUN mv mesa-r${MESAVERSION} mesa
+RUN wget --no-verbose -U "" -O /mesa.zip https://zenodo.org/records/3698354/files/mesa-r${MESAVERSION}.zip?download=1 &&\
+    unzip /mesa.zip &&\
+    rm mesa.zip &&\
+    mv mesa-r${MESAVERSION} mesa
 
 COPY etc_ld.so.conf.d_mesasdk.conf /etc/ld.so.conf.d/mesasdk.conf
 RUN ldconfig

--- a/docker-mesa-src/Dockerfile
+++ b/docker-mesa-src/Dockerfile
@@ -1,22 +1,23 @@
-FROM python:3.7-stretch
+FROM python:3.11-bookworm
 
 ARG MESASDKVERSION=20.3.2
 ARG MESAVERSION=12778
 
 RUN ln -sfv /bin/bash /bin/sh
 
-# RUN apt-get update &&\
-RUN apt-get install -y binutils bzip2 libc-dev libx11-dev libz-dev make wget &&\
+RUN apt-get update &&\
+    apt-get install -y binutils bzip2 libc-dev libx11-dev libz-dev make wget &&\
     apt-get clean -y &&\
     rm -rf /var/lib/apt/lists/* &&\
     truncate -s 0 /var/log/*log
 
 RUN wget --no-verbose -U "" -O /mesasdk.tar.gz http://user.astro.wisc.edu/~townsend/resource/download/mesasdk/mesasdk-x86_64-linux-${MESASDKVERSION}.tar.gz &&\
     tar -xvf /mesasdk.tar.gz
-#     rm /mesasdk.tar.gz
+RUN rm /mesasdk.tar.gz
 
 RUN wget --no-verbose -U "" -O /mesa.zip https://zenodo.org/records/3698354/files/mesa-r12778.zip?download=1
-RUN unzip /mesa.zip
+RUN unzip /mesa.zip && rm mesa.zip
+RUN mv mesa-r12778 mesa
 
 COPY etc_ld.so.conf.d_mesasdk.conf /etc/ld.so.conf.d/mesasdk.conf
 RUN ldconfig


### PR DESCRIPTION
I've just updated MESASDK and MESA source links. Unfortunately, the new ZENODO link is not user-friendly and is hardcoded into the Dockerfile. 
Also, I deleted the installing subversion command, as we no longer need it. 
!!! ISSUES: 'apt-get update' return a lot of errors while installing the MESASDK (in docker-mesa-src), as well as while compiling MESA (in the root directory) together with other 'apt-get' commands. For now, the 'apt-get update' command is commented in the Dockerfile in docker-mesa-src. 